### PR TITLE
進行状況(prgress flag=False)のときに例外が発生するバグの修正

### DIFF
--- a/pyzaim/pyzaim.py
+++ b/pyzaim/pyzaim.py
@@ -391,23 +391,24 @@ class ZaimCrawler:
         print("Found {} days in {}/{}.".format(day_len, year, month))
         self.current = day_len
         if progress:
-            pbar = tqdm(total=day_len)
+            self.pbar = tqdm(total=day_len)
 
         # データが一画面に収まらない場合には、スクロールして繰り返し読み込みする
         loop = True
         while loop:
-            loop = self.crawler(pbar, year, progress)
+            loop = self.crawler(year, progress)
 
         if progress:
-            pbar.update(self.current)
-            pbar.close()
+            self.pbar.update(self.current)
+            self.pbar.close()
 
         return reversed(self.data)
 
     def close(self):
         self.driver.close()
+        
 
-    def crawler(self, pbar, year, progress):
+    def crawler(self, year, progress):
         table = self.driver.find_element_by_xpath(
             "//*[starts-with(@class, 'SearchResult-module__list___')]")
         lines = table.find_elements_by_xpath(
@@ -471,7 +472,7 @@ class ZaimCrawler:
             tmp_day = item["date"].day
 
             if progress:
-                pbar.update(self.current - tmp_day)
+                self.pbar.update(self.current - tmp_day)
                 self.current = tmp_day
 
         # 画面をスクロールして、まだ新しい要素が残っている場合はループを繰り返す


### PR DESCRIPTION
はじめまして．
個人的に利用させて頂いているものです．

progress=FalseでZaimCrawlerを動作させた時に以下の例外により失敗することへの修正です．

```
UnboundLocalError: local variable 'pbar' referenced before assignment
```

pbarをメンバ変数としています．


