### PR TITLE
ZaimAPI get_data で params を指定できるようにする

### DIFF
--- a/pyzaim/pyzaim.py
+++ b/pyzaim/pyzaim.py
@@ -78,8 +78,8 @@ class ZaimAPI:
     def verify(self):
         return self.auth.get(self.verify_url).json()
 
-    def get_data(self):
-        return self.auth.get(self.money_url).json()["money"]
+    def get_data(self, params=None):
+        return self.auth.get(self.money_url, params=params).json()["money"]
 
     def insert_payment_simple(
         self,


### PR DESCRIPTION
はじめまして。

個人的に欲しい機能として、ZaimAPI の get_data にて params を指定できるようにしました。
以下のような使い方を意図してます。
```python
params = {
    "start_date": "2022-01-01",
    "end_date": "2022-12-31",
}
data = zaim_api.get_data(params=params)
```

雑ですが、問題なければマージしていただけると嬉しいです。